### PR TITLE
Update map.js

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1727,7 +1727,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
 
         if (result.pokemon.length) {
             $.each(result.pokemon, function (i, pokemon) {
-                var perfectPercent = getIv(pokemon.iv_attack, pokemon.iv_defense, pokemon.iv_stamina)
+                var perfectPercent = getIv(pokemon.iv_attack, pokemon.iv_defense, pokemon.iv_stamina).toFixed(2)
                 var moveEnergy = Math.round(100 / pokemon.move_2_energy)
 
                 pokemonHtml += `


### PR DESCRIPTION
Rounding Pokémon IV in sidebar to 2 decimals.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rounding the Pokémon IV to 2 decimals.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents displaying IV values as "86.66666666666667%". It will be changed to "86.67%"
100% will be displayed as 100.00%
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in browser.
## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/19438229/22212040/774c2f90-e18f-11e6-9abc-3fc295792e6a.png)
![image](https://cloud.githubusercontent.com/assets/19438229/22212066/8f397b08-e18f-11e6-834b-4a2375a0677e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
